### PR TITLE
Link NVIDIA application profiles

### DIFF
--- a/NVIDIA-Driver/post_install.bash
+++ b/NVIDIA-Driver/post_install.bash
@@ -6,6 +6,10 @@ if [ "$(whoami)" != 'root' ]; then
   exit 1
 fi
 
+## Link NVIDIA application profiles to where they are searched for
+echo -e "\e[33m\xe2\x8f\xb3 Optimizing Application Performance ...\e[m"
+ln -s /etc/nvidia /usr/share
+
 ## Validate that nvidia kernel modules are loaded
 echo -e "\e[33m\xe2\x8f\xb3 Making sure NVIDIA kernel modules are loaded ...\e[m"
 lsmod | grep ^nvidia


### PR DESCRIPTION
this was causing the error 

ERROR: nvidia-settings could not find the registry key file. This file should have been installed along with this driver at either /usr/share/nvidia/nvidia-application-profiles-440.64-key-documentation or
       /usr/share/nvidia/nvidia-application-profiles-key-documentation. The application profiles will continue to work, but values cannot be prepopulated or validated, and will not be listed in the help text. Please see the README for
       possible values and descriptions.