### PR TITLE
Added some workarounds for known issues, reviews appreciated

### DIFF
--- a/NVIDIA-Driver/pre_install.bash
+++ b/NVIDIA-Driver/pre_install.bash
@@ -69,7 +69,7 @@ sudo clr-boot-manager update
 # Disable nouveau driver
 echo -e "\e[33m\xe2\x8f\xb3 Disabling nouveau Driver ...\e[m"
 if [ ! -d /etc/modprobe.d ]; then
-  sudo mkdir /etc/modprobe.d
+  sudo mkdir -p /etc/modprobe.d
 fi
 cat <<EOF | sudo tee /etc/modprobe.d/disable-nouveau.conf > /dev/null
 blacklist nouveau


### PR DESCRIPTION
Just as the title says, might need some polish, especially considering that all the DKMS stuff has no impact since we are not using it anymore. This has never been a problem IMO: every OS update I always had to reinstall the drivers anyway.
Another thing is that the installer is NOT run silently: if the generated keys get dropped, installation fails, and I found no command line option to keep them (if there is, then we can make the installer silent again, and avoid user confusion) 