### PR TITLE
Fix For Systemd Service Suspend/Resume

### DIFF
--- a/NVIDIA-Driver/post_install.bash
+++ b/NVIDIA-Driver/post_install.bash
@@ -11,6 +11,13 @@ fi
 echo -e "\e[33m\xe2\x8f\xb3 Updating the flatpak runtime ...\e[m"
 flatpak update -y
 
+# Fix Suspend/Resume Service Files
+echo -e "\e[33m\xe2\x8f\xb3 Modifying Nvidia Service Files ...\e[m"
+
+sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' /etc/systemd/system/systemd-suspend.service.requires/nvidia-suspend.service
+sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' /etc/systemd/system/systemd-suspend.service.requires/nvidia-resume.service
+
+sudo systemctl daemon-reload
 # Optionally ask user whether to add a desktop file for "nvidia-settings"
 if ! [ -f "$HOME"/.local/share/applications/nvidia-settings.desktop ]; then
   read -rp "Do you want to add a desktop file for \"nvidia-settings\"? (Y/n)" -n1 -s

--- a/NVIDIA-Driver/post_update.bash
+++ b/NVIDIA-Driver/post_update.bash
@@ -11,6 +11,14 @@ fi
 echo -e "\e[33m\xe2\x8f\xb3 Updating the flatpak runtime ...\e[m"
 flatpak update -y
 
+# Fix Suspend/Resume Service Files
+echo -e "\e[33m\xe2\x8f\xb3 Modifying Nvidia Service Files ...\e[m"
+
+sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' /etc/systemd/system/systemd-suspend.service.requires/nvidia-suspend.service
+sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' /etc/systemd/system/systemd-suspend.service.requires/nvidia-resume.service
+
+sudo systemctl daemon-reload
+
 # Optionally ask user whether to add a desktop file for "nvidia-settings"
 if ! [ -f "$HOME"/.local/share/applications/nvidia-settings.desktop ]; then
   read -rp "Do you want to add a desktop file for \"nvidia-settings\"? (Y/n)" -n1 -s


### PR DESCRIPTION
## Problem
Because the installation is put under `/opt/nvidia` , systemd services doesn't adapt to that specified directory, which means both files:
- `/etc/systemd/system/systemd-suspend.service.requires/nvidia-suspend.service`
-  `/etc/systemd/system/systemd-suspend.service.requires/nvidia-resume.service`

references the `/usr/bin` directory.
Because of that, the call for `nvidia-sleep.sh` is not executed upon system suspend because it cannot find the file.

This causes issues with suspend / wake up, where the system isn't allowed to suspend because the Nvidia driver is sending signals constantly. 
 
## Fix
As a solution, I simply modify both the post update and post install scripts to modify the path for nvidia-sleep.sh on the systemd files that uses them.
