### PR TITLE
Minor Fix for Pre-Update Script for Version Check

### DIFF
--- a/NVIDIA-Driver/pre_update.bash
+++ b/NVIDIA-Driver/pre_update.bash
@@ -27,11 +27,11 @@ if [ -z "$LATEST" ]; then
   exit 1
 else
   echo -e "\e[32m The latest version is \e[33m${LATEST}\e[m"
-  CURRENT_ARR=($(s:.:)CURRENT)
-  LATEST_ARR=($(s:.:)LATEST)
+  IFS='.' read -ra CURRENT_ARR <<< "$CURRENT"
+  IFS='.' read -ra LATEST_ARR <<< "$LATEST"
   NEED_UPDATE=1
-  for (( i = 1; i <= ${#CURRENT_ARR}; i += 1)); do
-      if (( ${CURRENT_ARR[i] >= ${LATEST_ARR[i]}} )); then
+  for (( i = 0; i <= ${#CURRENT_ARR}; i += 1)); do
+      if [ ${CURRENT_ARR[i]} -ge ${LATEST_ARR[i]} ]; then
           NEED_UPDATE=0
           break
       fi


### PR DESCRIPTION
### Problem
For some reason, the script doesn't like the parameter expansion on the `$CURRENT` and `$LATEST` , according to the latest reply on the forum.

Here is a snippet for the error:
```
pre_update.bash: line 30: s:.:: command not found
pre_update.bash: line 31: s:.:: command not found
pre_update.bash: line 34:  ${CURRENT_ARR[i] >= ${LATEST_ARR[i]}} : bad substitution
```

### Solution
I changed the script so that it reads using IFS, that should make the solution more reliable. (can work across shells?) 
The pull request is also for checking the first split of the version string. (once nvidia releases >470)