### PR TITLE
Fixed Version Check once again

### DIFF
--- a/NVIDIA-Driver/pre_update.bash
+++ b/NVIDIA-Driver/pre_update.bash
@@ -27,16 +27,7 @@ if [ -z "$LATEST" ]; then
   exit 1
 else
   echo -e "\e[32m The latest version is \e[33m${LATEST}\e[m"
-  IFS='.' read -ra CURRENT_ARR <<< "$CURRENT"
-  IFS='.' read -ra LATEST_ARR <<< "$LATEST"
-  NEED_UPDATE=1
-  for (( i = 0; i <= ${#CURRENT_ARR}; i += 1)); do
-      if [ ${CURRENT_ARR[i]} -ge ${LATEST_ARR[i]} ]; then
-          NEED_UPDATE=0
-          break
-      fi
-  done
-  if (( NEED_UPDATE )); then
+  if [ "$(printf '%s\n' "$LATEST" "$CURRENT" | sort -V | head -n1)" != "$LATEST" ]; then
     if [ -f "./NVIDIA-Linux-x86_64-${LATEST}.run" ]; then
       echo -e "\e[32m The installer for the latest driver is already downloaded.\e[m"
     else


### PR DESCRIPTION
Apparently, the previous commit have few problems with version check, especially when the current version have a lower start and higher end or vice versa. 

To make sure this commit will fix the issue, here is a test script:
```
#!/usr/bin/env bash
CURRENT="470.44.10"
LATEST="471.55.10"


  if [ "$(printf '%s\n' "$LATEST" "$CURRENT" | sort -V | head -n1)" != "$LATEST" ]; then 
        echo "CURRENT VERSION IS LESS THAN ${LATEST}"
  else
        echo "CURRENT VERSION IS EQUAL OR GREATER THAN ${LATEST}"
  fi
```
changing the `CURRENT` variable from 470 to 480 or from .11 to .50 shouldn't change how the script compare the versions. (This applies if you change the `LATEST` variable values)

Hopefully this fixes all the issues with the version check and apologies for the last commit.
