### PR TITLE
Update service files

### DIFF
--- a/NVIDIA-Driver/post_update.bash
+++ b/NVIDIA-Driver/post_update.bash
@@ -14,8 +14,12 @@ flatpak update -y
 # Fix Suspend/Resume Service Files
 echo -e "\e[33m\xe2\x8f\xb3 Modifying Nvidia Service Files ...\e[m"
 
-sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' /etc/systemd/system/systemd-suspend.service.requires/nvidia-suspend.service
-sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' /etc/systemd/system/systemd-suspend.service.requires/nvidia-resume.service
+for n in nvidia-suspend nvidia-resume nvidia-hibernate; do
+  path=/usr/lib/systemd/system/$n.service
+  if [ -f $path ]; then
+    sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' $path
+  fi
+done
 
 sudo systemctl daemon-reload
 

--- a/NVIDIA-Driver/post_update.bash
+++ b/NVIDIA-Driver/post_update.bash
@@ -16,8 +16,8 @@ echo -e "\e[33m\xe2\x8f\xb3 Modifying Nvidia Service Files ...\e[m"
 
 for n in nvidia-suspend nvidia-resume nvidia-hibernate; do
   path=/usr/lib/systemd/system/$n.service
-  if [ -f $path ]; then
-    sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' $path
+  if [ -f "$path" ]; then
+    sudo sed -i 's|/usr/bin/nvidia-sleep.sh|/opt/nvidia/bin/nvidia-sleep.sh|g' "$path"
   fi
 done
 


### PR DESCRIPTION
Currently the post installation script updates 2 service files. This PR updates all three service files nvidia-suspend, nvidia-resume, and nvidia-hibernate residing in /usr/lib/systemd/system/. The files in /etc are symbolic links to /usr/lib/systemd/system/.

```text
/etc/systemd/system/systemd-suspend.service.requires/nvidia-suspend.service
/etc/systemd/system/systemd-suspend.service.requires/nvidia-resume.service
```
```text
/etc/systemd/system/systemd-hibernate.service.requires/nvidia-hibernate.service
/etc/systemd/system/systemd-hibernate.service.requires/nvidia-resume.service
```
