### PR TITLE
Update pre_update.sh

### DIFF
--- a/NVIDIA-Driver/pre_install.bash
+++ b/NVIDIA-Driver/pre_install.bash
@@ -35,7 +35,10 @@ BindsTo=update-triggers.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/ln -sfv /opt/nvidia/lib/libGL.so.1 /usr/lib/libGL.so.1
-ExecStart=/usr/bin/ln -sfv /opt/nvidia/lib32/libGL.so.1 /usr/lib32/libGL.so.1
+ExecStart=/usr/bin/sh -c '/usr/bin/rm -fv /usr/lib64/libEGL.so* /usr/lib32/libEGL.so*'
+ExecStart=/usr/bin/sh -c '/usr/bin/rm -fv /usr/lib64/libGLESv1_CM.so* /usr/lib32/libGLESv1_CM.so*'
+ExecStart=/usr/bin/sh -c '/usr/bin/rm -fv /usr/lib64/libGLESv2.so* /usr/lib32/libGLESv2.so*'
+ExecStart=/usr/bin/sh -c '/usr/bin/rm -fv /usr/lib64/libGL.so* /usr/lib32/libGL.so*'
 EOF
 
 ## Reload systemd daemon to find the new service


### PR DESCRIPTION
Add missing ExecStart entries removing Mesa libGL files that break the NVIDIA proprietary installation.

On a new Clear Linux installation, I captured carefully the result of the NVIDIA proprietary installation. That is only **one** symbolic link /usr/lib/libGL.so.1 exists pointing to /opt/nvidia/... The NVIDIA installer also removes libEGL.so*, libGLESv1_CM.so*, libGLESv2.so*, and libGL.so* files from /usr/lib64 and /usr/lib32.

Not just `update` but also `bundle-add` can break the NVIDIA installation. For example, running `swupd bundle-add devpkg-libva` installs Mesa libGL files mentioned above. The same is true for `devpkg-mediasdk` and `devpkg-mesa`.

This PR ensures the Mesa libGL files mentioned above are removed after running `swupd update` or `swupd bundle-add PKG`.

**Testing**

Update fix-nvidia-libGL-trigger.service as per the PR.

```bash
$ sudo systemctl daemon-reload
```

The `devpkg-libva` package is small in size about 98MB. Remove it if already installed so to see the trigger work as intended after adding the package.

```bash
$ sudo swupd bundle-remove devpkg-libva
$ sudo swupd bundle-add devpkg-libva
$ sudo swupd bundle-info devpkg-libva --files |egrep 'lib(EGL|GLES|GL\.)' |sort
```

Check the status and notice the removal of the Mesa libGL files. The devpkg-libva installs Mesa lib64 files. So you will not see removal entries for lib32. Unless a stale NVIDIA installation in which case it will bring to a good state.

```bash
$ systemctl status fix-nvidia-libGL-trigger.service
```
